### PR TITLE
Fix curation/hackathon label case in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/curation-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/curation-proposal.yml
@@ -1,7 +1,7 @@
 name: Curation Project Proposal
 description: Project proposal for the Variant Interpretation for Cancer Consortium, CIViC, and ClinGen Somatic Curation Jamboree
 title: "[Curation project title]"
-labels: ["2023", "Curation"]
+labels: ["2023", "curation"]
 
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/hackathon-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/hackathon-proposal.yml
@@ -1,7 +1,7 @@
 name: Hackathon Project Proposal
 description: Project proposal for the Variant Interpretation for Cancer Consortium, CIViC, and ClinGen Somatic Hackathon
 title: "[Hackathon project title]"
-labels: ["2023", "Hackathon"]
+labels: ["2023", "hackathon"]
 
 body:
   - type: input


### PR DESCRIPTION
We'll also want to add a `2023` label 